### PR TITLE
Fix NameError: ipex_cpu_only 

### DIFF
--- a/bitsandbytes/backends/cpu_xpu_common.py
+++ b/bitsandbytes/backends/cpu_xpu_common.py
@@ -1,7 +1,7 @@
+import os
 import subprocess
 from typing import Optional
 import warnings
-import os
 
 import torch
 
@@ -20,6 +20,7 @@ try:
 except BaseException:
     ipex_cpu = None
     ipex_xpu = None
+    ipex_cpu_only = None
 
 
 gxx_available = False


### PR DESCRIPTION
This PR resolves a NameError in the dequantize_4bit_impl function caused by undefined variable:ipex_cpu_only in bitsandbytes/backends/cpu_xpu_common.py
